### PR TITLE
Allow sendMediaGroup to recive resource

### DIFF
--- a/examples/send_album.php
+++ b/examples/send_album.php
@@ -1,0 +1,41 @@
+<?php
+
+use SergiX44\Nutgram\Nutgram;
+
+require 'vendor/autoload.php';
+
+$bot = new Nutgram($_ENV['TOKEN']);
+
+$bot->onText('/from_file', function (Nutgram $bot) {
+	file_put_contents('150.png',file_get_contents('https://via.placeholder.com/150'));
+	file_put_contents('200.png',file_get_contents('https://via.placeholder.com/200'));
+    $bot->sendMediaGroup([
+		[
+			'type' => 'photo',
+			'media' => 'attach://photoa'
+		],
+		[
+			'type' => 'photo',
+			'media' => 'attach://photob'
+		],
+	],[
+		'photoa' => fopen('150.png','r+'),
+		'photob' => fopen('200.png','r+')
+	]);
+});
+
+$bot->onText('/from_url', function (Nutgram $bot) {
+    $bot->sendMediaGroup([
+		[
+			'type' => 'photo',
+			'media' => 'https://via.placeholder.com/150'
+		],
+		[
+			'type' => 'photo',
+			'media' => 'https://via.placeholder.com/200'
+		],
+	]);
+});
+
+$bot->run();
+

--- a/src/Telegram/Client.php
+++ b/src/Telegram/Client.php
@@ -164,57 +164,6 @@ trait Client
             return $this->mapResponse($response, $mapTo, $exception);
         }
     }
-
-    /**
-     * @param  string  $endpoint
-     * @param  array|null  $multipart
-     * @param  string  $mapTo
-     * @param  array|null  $options
-     * @return mixed
-     */
-    protected function requestMultipleMultipart(
-        string $endpoint,
-        ?array $multipart = null,
-        string $mapTo = stdClass::class,
-        ?array $options = []
-    ): mixed {
-        $parameters = [];
-
-        foreach ($multipart as $name => $contents) {
-            if (is_array($contents)) {
-                foreach ($contents as $key => $subcontent) {
-                    $parameters[] = [
-                        'name' => $subcontent['type'] . $key,
-                        'contents' => $subcontent['media'],
-                    ];
-                    $media[] = [
-                        'type' => $subcontent['type'],
-                        'media' => 'attach://' . $subcontent['type'] . $key
-                    ];
-                }
-            } else {
-                $parameters[] = [
-                    'name' => $name,
-                    'contents' => $contents,
-                ];
-            }
-        }
-        $parameters[] = [
-            'name' => 'media',
-            'contents' => json_encode($media),
-        ];
-
-        try {
-            $response = $this->http->post($endpoint, array_merge(['multipart' => $parameters], $options));
-            return $this->mapResponse($response, $mapTo);
-        } catch (RequestException $exception) {
-            if (!$exception->hasResponse()) {
-                throw $exception;
-            }
-            $response = $exception->getResponse();
-            return $this->mapResponse($response, $mapTo, $exception);
-        }
-    }
     
     /**
      * @param  string  $endpoint

--- a/src/Telegram/Client.php
+++ b/src/Telegram/Client.php
@@ -167,6 +167,57 @@ trait Client
 
     /**
      * @param  string  $endpoint
+     * @param  array|null  $multipart
+     * @param  string  $mapTo
+     * @param  array|null  $options
+     * @return mixed
+     */
+    protected function requestMultipleMultipart(
+        string $endpoint,
+        ?array $multipart = null,
+        string $mapTo = stdClass::class,
+        ?array $options = []
+    ): mixed {
+        $parameters = [];
+
+        foreach ($multipart as $name => $contents) {
+            if (is_array($contents)) {
+                foreach ($contents as $key => $subcontent) {
+                    $parameters[] = [
+                        'name' => $subcontent['type'] . $key,
+                        'contents' => $subcontent['media'],
+                    ];
+                    $media[] = [
+                        'type' => $subcontent['type'],
+                        'media' => 'attach://' . $subcontent['type'] . $key
+                    ];
+                }
+            } else {
+                $parameters[] = [
+                    'name' => $name,
+                    'contents' => $contents,
+                ];
+            }
+        }
+        $parameters[] = [
+            'name' => 'media',
+            'contents' => json_encode($media),
+        ];
+
+        try {
+            $response = $this->http->post($endpoint, array_merge(['multipart' => $parameters], $options));
+            return $this->mapResponse($response, $mapTo);
+        } catch (RequestException $exception) {
+            if (!$exception->hasResponse()) {
+                throw $exception;
+            }
+            $response = $exception->getResponse();
+            return $this->mapResponse($response, $mapTo, $exception);
+        }
+    }
+    
+    /**
+     * @param  string  $endpoint
      * @param  array|null  $json
      * @param  string  $mapTo
      * @param  array|null  $options

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -161,19 +161,11 @@ trait AvailableMethods
      */
     public function sendMediaGroup(array $media, array $opt = []): ?array
     {
-        if (isset($opt['multipart']) && $opt['multipart']) {
-            $required = [
-                'chat_id' => $this->chatId(),
-                'media' => $media,
-            ];
-            return $this->requestMultipleMultipart(__FUNCTION__, array_merge($required, $opt), Message::class);
-        } else {
-            $required = [
-                'chat_id' => $this->chatId(),
-                'media' => json_encode($media),
-            ];
-            return $this->requestJson(__FUNCTION__, array_merge($required, $opt), Message::class);
-        }
+		$required = [
+			'chat_id' => $this->chatId(),
+			'media' => json_encode($media),
+		];
+		return $this->requestMultipart(__FUNCTION__, array_merge($required, $opt), Message::class);
     }
 
     /**

--- a/src/Telegram/Endpoints/AvailableMethods.php
+++ b/src/Telegram/Endpoints/AvailableMethods.php
@@ -161,11 +161,19 @@ trait AvailableMethods
      */
     public function sendMediaGroup(array $media, array $opt = []): ?array
     {
-        $required = [
-            'chat_id' => $this->chatId(),
-            'media' => json_encode($media),
-        ];
-        return $this->requestJson(__FUNCTION__, array_merge($required, $opt), Message::class);
+        if (isset($opt['multipart']) && $opt['multipart']) {
+            $required = [
+                'chat_id' => $this->chatId(),
+                'media' => $media,
+            ];
+            return $this->requestMultipleMultipart(__FUNCTION__, array_merge($required, $opt), Message::class);
+        } else {
+            $required = [
+                'chat_id' => $this->chatId(),
+                'media' => json_encode($media),
+            ];
+            return $this->requestJson(__FUNCTION__, array_merge($required, $opt), Message::class);
+        }
     }
 
     /**


### PR DESCRIPTION
With the current implementation sendMediaGroup don't work when resource is passed because `json_encode` is unable to serialize the resource.

Request field need to match [input media](https://core.telegram.org/bots/api#inputmediaphoto) requirements for resource upload.