### PR TITLE
fix wrong handler with animation message type

### DIFF
--- a/src/Telegram/Types/Message/Message.php
+++ b/src/Telegram/Types/Message/Message.php
@@ -399,8 +399,8 @@ class Message
         return match (true) {
             $this->text !== null => MessageTypes::TEXT,
             $this->audio !== null => MessageTypes::AUDIO,
-            $this->document !== null => MessageTypes::DOCUMENT,
             $this->animation !== null => MessageTypes::ANIMATION,
+            $this->document !== null => MessageTypes::DOCUMENT,
             $this->game !== null => MessageTypes::GAME,
             $this->photo !== null => MessageTypes::PHOTO,
             $this->sticker !== null => MessageTypes::STICKER,


### PR DESCRIPTION
When you send a GIF, the called handler will be `$bot->onMessageType(MessageTypes::DOCUMENT)` instead of `$bot->onMessageType(MessageTypes::ANIMATION)`.

**Caused by** document field in https://core.telegram.org/bots/api#message:
_"animation: Optional. Message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set"_

**Fixed by** reordering _animation_ and _document_ in `getType` method in `Message` class.

**Wrong behavior:**
![immagine](https://user-images.githubusercontent.com/4071613/155021525-b5001c6f-6b4d-4129-8794-95651fd4bd05.png)


**Right behavior:**
![immagine](https://user-images.githubusercontent.com/4071613/155021516-413938b6-8989-4db9-830f-a3f731846240.png)
